### PR TITLE
Remove delay from trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,9 @@ keywords = ["embedded-hal-driver","lora","sx1276","radio"]
 description = "A platform-agnostic driver for Semtech SX1276/77/78/79 based boards."
 
 [dependencies]
-embedded-hal = "0.2.2"
-bit_field = "0.9.0"
+embedded-hal = "~0.2"
+bit_field = "~0.10"
+
+[features]
+version_0x09 = []
+default = []

--- a/examples/pi_simple_send.rs
+++ b/examples/pi_simple_send.rs
@@ -1,18 +1,17 @@
 #![feature(extern_crate_item_prelude)]
-extern crate sx127x_lora;
 extern crate linux_embedded_hal as hal;
+extern crate sx127x_lora;
 
 use hal::spidev::{self, SpidevOptions};
-use hal::{Pin, Spidev};
 use hal::sysfs_gpio::Direction;
 use hal::Delay;
+use hal::{Pin, Spidev};
 
 const LORA_CS_PIN: u64 = 8;
 const LORA_RESET_PIN: u64 = 21;
 const FREQUENCY: i64 = 915;
 
-fn main(){
-
+fn main() {
     let mut spi = Spidev::open("/dev/spidev0.0").unwrap();
     let options = SpidevOptions::new()
         .bits_per_word(8)
@@ -29,19 +28,18 @@ fn main(){
     reset.export().unwrap();
     reset.set_direction(Direction::Out).unwrap();
 
-    let mut lora = sx127x_lora::LoRa::new(
-        spi, cs, reset,  FREQUENCY, Delay)
+    let mut lora = sx127x_lora::LoRa::new(spi, cs, reset, FREQUENCY, Delay)
         .expect("Failed to communicate with radio module!");
 
-    lora.set_tx_power(17,1); //Using PA_BOOST. See your board for correct pin.
+    lora.set_tx_power(17, 1); //Using PA_BOOST. See your board for correct pin.
 
     let message = "Hello, world!";
-    let mut buffer = [0;255];
-    for (i,c) in message.chars().enumerate() {
+    let mut buffer = [0; 255];
+    for (i, c) in message.chars().enumerate() {
         buffer[i] = c as u8;
     }
 
-    let transmit = lora.transmit_payload(buffer,message.len());
+    let transmit = lora.transmit_payload(buffer, message.len());
     match transmit {
         Ok(packet_size) => println!("Sent packet with size: {}", packet_size),
         Err(()) => println!("Error"),

--- a/examples/stm32f4_receive.rs
+++ b/examples/stm32f4_receive.rs
@@ -1,24 +1,24 @@
 #![no_std]
 #![no_main]
 
-extern crate sx127x_lora;
-extern crate stm32f429_hal as hal;
 extern crate cortex_m;
 extern crate panic_semihosting;
+extern crate stm32f429_hal as hal;
+extern crate sx127x_lora;
 
-use sx127x_lora::MODE;
 use cortex_m_semihosting::*;
-use hal::gpio::GpioExt;
-use hal::flash::FlashExt;
-use hal::rcc::RccExt;
-use hal::time::MegaHertz;
-use hal::spi::Spi;
 use hal::delay::Delay;
+use hal::flash::FlashExt;
+use hal::gpio::GpioExt;
+use hal::rcc::RccExt;
+use hal::spi::Spi;
+use hal::time::MegaHertz;
+use sx127x_lora::MODE;
 
 const FREQUENCY: i64 = 915;
 
 #[entry]
-fn main() -> !{
+fn main() -> ! {
     let cp = cortex_m::Peripherals::take().unwrap();
     let p = hal::stm32f429::Peripherals::take().unwrap();
 
@@ -37,8 +37,12 @@ fn main() -> !{
     let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
     let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
     let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-    let reset = gpiof.pf13.into_push_pull_output(&mut gpiof.moder, &mut gpiof.otyper);
-    let cs = gpiod.pd14.into_push_pull_output(&mut gpiod.moder, &mut gpiod.otyper);
+    let reset = gpiof
+        .pf13
+        .into_push_pull_output(&mut gpiof.moder, &mut gpiof.otyper);
+    let cs = gpiod
+        .pd14
+        .into_push_pull_output(&mut gpiod.moder, &mut gpiod.otyper);
 
     let spi = Spi::spi1(
         p.SPI1,
@@ -49,24 +53,27 @@ fn main() -> !{
         &mut rcc.apb2,
     );
 
-    let mut lora = sx127x_lora::LoRa::new(
-        spi, cs, reset, FREQUENCY,
-        Delay::new(cp.SYST, clocks)).unwrap();
+    let mut lora =
+        sx127x_lora::LoRa::new(spi, cs, reset, FREQUENCY, Delay::new(cp.SYST, clocks)).unwrap();
 
     loop {
         let poll = lora.poll_irq(Some(30)); //30 Second timeout
         match poll {
-            Ok(size) =>{
-                hprintln!("New Packet with size {} and RSSI: {}", size,lora.get_packet_rssi()).unwrap();
+            Ok(size) => {
+                hprintln!(
+                    "New Packet with size {} and RSSI: {}",
+                    size,
+                    lora.get_packet_rssi()
+                )
+                .unwrap();
                 let buffer = lora.read_packet(); // Received buffer. NOTE: 255 bytes are always returned
                 hprint!("with Payload: ");
-                for i in 0..size{
-                    hprint!("{}",buffer[i] as char).unwrap();
+                for i in 0..size {
+                    hprint!("{}", buffer[i] as char).unwrap();
                 }
                 hprintln!();
-            },
+            }
             Err(()) => hprintln!("Timeout").unwrap(),
         }
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,16 +145,16 @@
 //! support is available in `embedded-hal`, then this will be added. It is possible to implement this function on a
 //! device-to-device basis by retrieving a packet with the `read_packet()` function.
 
-use embedded_hal::digital::v2::OutputPin;
-use embedded_hal::blocking::spi::{Transfer, Write};
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::spi::{Mode, Phase, Polarity};
 use bit_field::BitField;
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::spi::{Transfer, Write};
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::spi::{Mode, Phase, Polarity};
 
 mod register;
+use self::register::PaConfig;
 use self::register::Register;
 use self::register::IRQ;
-use self::register::PaConfig;
 
 /// Provides the necessary SPI mode configuration for the radio
 pub const MODE: Mode = Mode {
@@ -191,13 +191,20 @@ const VERSION_CHECK: u8 = 0x12;
 const VERSION_CHECK: u8 = 0x09;
 
 impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
-    where SPI: Transfer<u8, Error = E> + Write<u8, Error = E>,
-          CS: OutputPin, RESET: OutputPin {
+where
+    SPI: Transfer<u8, Error = E> + Write<u8, Error = E>,
+    CS: OutputPin,
+    RESET: OutputPin,
+{
     /// Builds and returns a new instance of the radio. Only one instance of the radio should exist at a time.
     /// This also preforms a hardware reset of the module and then puts it in standby.
-    pub fn new(spi: SPI, cs: CS, reset: RESET, frequency: i64, delay: &mut dyn DelayMs<u8>)
-               -> Result<Self, Error<E, CS::Error, RESET::Error>> {
-
+    pub fn new(
+        spi: SPI,
+        cs: CS,
+        reset: RESET,
+        frequency: i64,
+        delay: &mut dyn DelayMs<u8>,
+    ) -> Result<Self, Error<E, CS::Error, RESET::Error>> {
         let mut sx127x = LoRa {
             spi,
             cs,
@@ -214,8 +221,8 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         if version == VERSION_CHECK {
             sx127x.set_mode(RadioMode::Sleep)?;
             sx127x.set_frequency(frequency)?;
-            sx127x.write_register(Register::RegFifoTxBaseAddr.addr(),0)?;
-            sx127x.write_register(Register::RegFifoRxBaseAddr.addr(),0)?;
+            sx127x.write_register(Register::RegFifoTxBaseAddr.addr(), 0)?;
+            sx127x.write_register(Register::RegFifoRxBaseAddr.addr(), 0)?;
             let lna = sx127x.read_register(Register::RegLna.addr())?;
             sx127x.write_register(Register::RegLna.addr(), lna | 0x03)?;
             sx127x.write_register(Register::RegModemConfig3.addr(), 0x04)?;
@@ -229,54 +236,60 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
 
     /// Transmits up to 255 bytes of data. To avoid the use of an allocator, this takes a fixed 255 u8
     /// array and a payload size and returns the number of bytes sent if successful.
-    pub fn transmit_payload_busy(&mut self, buffer: [u8; 255], payload_size: usize)
-                            -> Result<usize,Error<E, CS::Error, RESET::Error>>{
+    pub fn transmit_payload_busy(
+        &mut self,
+        buffer: [u8; 255],
+        payload_size: usize,
+    ) -> Result<usize, Error<E, CS::Error, RESET::Error>> {
         if self.transmitting()? {
             Err(Transmitting)
-        }else{
+        } else {
             self.set_mode(RadioMode::Stdby)?;
             if self.explicit_header {
                 self.set_explicit_header_mode()?;
-            }else{
+            } else {
                 self.set_implicit_header_mode()?;
             }
 
             self.write_register(Register::RegIrqFlags.addr(), 0)?;
             self.write_register(Register::RegFifoAddrPtr.addr(), 0)?;
             self.write_register(Register::RegPayloadLength.addr(), 0)?;
-            for byte in buffer.iter().take(payload_size){
+            for byte in buffer.iter().take(payload_size) {
                 self.write_register(Register::RegFifo.addr(), *byte)?;
             }
-            self.write_register(Register::RegPayloadLength.addr(),payload_size as u8)?;
+            self.write_register(Register::RegPayloadLength.addr(), payload_size as u8)?;
             self.set_mode(RadioMode::Tx)?;
-            while self.transmitting()? {};
+            while self.transmitting()? {}
             Ok(payload_size)
         }
     }
 
-    pub fn set_dio0_tx_done(&mut self) -> Result<(),Error<E, CS::Error, RESET::Error>> {
+    pub fn set_dio0_tx_done(&mut self) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         self.write_register(Register::RegDioMapping1.addr(), 0b01_00_00_00)
     }
 
-    pub fn transmit_payload(&mut self, buffer: [u8; 255], payload_size: usize)
-                            -> Result<(),Error<E, CS::Error, RESET::Error>>{
+    pub fn transmit_payload(
+        &mut self,
+        buffer: [u8; 255],
+        payload_size: usize,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if self.transmitting()? {
             Err(Transmitting)
-        }else{
+        } else {
             self.set_mode(RadioMode::Stdby)?;
             if self.explicit_header {
                 self.set_explicit_header_mode()?;
-            }else{
+            } else {
                 self.set_implicit_header_mode()?;
             }
 
             self.write_register(Register::RegIrqFlags.addr(), 0)?;
             self.write_register(Register::RegFifoAddrPtr.addr(), 0)?;
             self.write_register(Register::RegPayloadLength.addr(), 0)?;
-            for byte in buffer.iter().take(payload_size){
+            for byte in buffer.iter().take(payload_size) {
                 self.write_register(Register::RegFifo.addr(), *byte)?;
             }
-            self.write_register(Register::RegPayloadLength.addr(),payload_size as u8)?;
+            self.write_register(Register::RegPayloadLength.addr(), payload_size as u8)?;
             self.set_mode(RadioMode::Tx)?;
             Ok(())
         }
@@ -285,14 +298,18 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Blocks the current thread, returning the size of a packet if one is received or an error is the
     /// task timed out. The timeout can be supplied with None to make it poll indefinitely or
     /// with `Some(timeout_in_mill_seconds)`
-    pub fn poll_irq(&mut self, timeout_ms: Option<i32>, delay: &mut dyn DelayMs<u8>) -> Result<usize,Error<E, CS::Error, RESET::Error>>{
+    pub fn poll_irq(
+        &mut self,
+        timeout_ms: Option<i32>,
+        delay: &mut dyn DelayMs<u8>,
+    ) -> Result<usize, Error<E, CS::Error, RESET::Error>> {
         self.set_mode(RadioMode::RxContinuous)?;
         match timeout_ms {
             Some(value) => {
                 let mut count = 0;
                 let packet_ready = loop {
                     let packet_ready = self.read_register(Register::RegIrqFlags.addr())?.get_bit(6);
-                    if count >= value || packet_ready  {
+                    if count >= value || packet_ready {
                         break packet_ready;
                     }
                     count += 1;
@@ -304,7 +321,7 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
                 } else {
                     Err(Uninformative)
                 }
-            },
+            }
             None => {
                 while !self.read_register(Register::RegIrqFlags.addr())?.get_bit(6) {
                     delay.delay_ms(100);
@@ -313,8 +330,6 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
                 Ok(self.read_register(Register::RegRxNbBytes.addr())? as usize)
             }
         }
-
-
     }
 
     /// Returns the contents of the fifo as a fixed 255 u8 array. This should only be called is there is a
@@ -336,13 +351,13 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Returns true if the radio is currently transmitting a packet.
     pub fn transmitting(&mut self) -> Result<bool, Error<E, CS::Error, RESET::Error>> {
         if (self.read_register(Register::RegOpMode.addr())? & RadioMode::Tx.addr())
-            == RadioMode::Tx.addr() {
+            == RadioMode::Tx.addr()
+        {
             Ok(true)
-        }else{
-            if (self.read_register(Register::RegIrqFlags.addr())?
-                & IRQ::IrqTxDoneMask.addr()) == 1{
-                self.write_register(Register::RegIrqFlags.addr(),
-                                    IRQ::IrqTxDoneMask.addr())?;
+        } else {
+            if (self.read_register(Register::RegIrqFlags.addr())? & IRQ::IrqTxDoneMask.addr()) == 1
+            {
+                self.write_register(Register::RegIrqFlags.addr(), IRQ::IrqTxDoneMask.addr())?;
             }
             Ok(false)
         }
@@ -354,11 +369,14 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         self.write_register(Register::RegIrqFlags.addr(), irq_flags)
     }
 
-
     /// Sets the transmit power and pin. Levels can range from 0-14 when the output
     /// pin = 0(RFO), and form 0-20 when output pin = 1(PaBoost). Power is in dB.
     /// Default value is `17`.
-    pub fn set_tx_power(&mut self, mut level: i32, output_pin: u8) -> Result<(), Error<E, CS::Error, RESET::Error>>{
+    pub fn set_tx_power(
+        &mut self,
+        mut level: i32,
+        output_pin: u8,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if PaConfig::PaOutputRfoPin.addr() == output_pin {
             // RFO
             if level < 0 {
@@ -379,7 +397,7 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
                 // High Power +20 dBm Operation (Semtech SX1276/77/78/79 5.4.3.)
                 self.write_register(Register::RegPaDac.addr(), 0x87)?;
                 self.set_ocp(140)?;
-            }else {
+            } else {
                 if level < 2 {
                     level = 2;
                 }
@@ -388,32 +406,36 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
                 self.set_ocp(100)?;
             }
             level -= 2;
-            self.write_register(Register::RegPaConfig.addr(), PaConfig::PaBoost.addr()
-                | level as u8)
+            self.write_register(
+                Register::RegPaConfig.addr(),
+                PaConfig::PaBoost.addr() | level as u8,
+            )
         }
     }
 
     /// Sets the over current protection on the radio(mA).
-    pub fn set_ocp(&mut self, ma: u8) -> Result<(), Error<E, CS::Error, RESET::Error>>{
+    pub fn set_ocp(&mut self, ma: u8) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         let mut ocp_trim: u8 = 27;
 
         if ma <= 120 {
             ocp_trim = (ma - 45) / 5;
-        } else if ma <=240 {
+        } else if ma <= 240 {
             ocp_trim = (ma + 30) / 10;
         }
         self.write_register(Register::RegOcp.addr(), 0x20 | (0x1F & ocp_trim))
     }
 
     /// Sets the state of the radio. Default mode after initiation is `Standby`.
-    pub fn set_mode(&mut self,mode: RadioMode) -> Result<(), Error<E, CS::Error, RESET::Error>> {
+    pub fn set_mode(&mut self, mode: RadioMode) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if self.explicit_header {
             self.set_explicit_header_mode()?;
-        }else{
+        } else {
             self.set_implicit_header_mode()?;
         }
-        self.write_register(Register::RegOpMode.addr(),RadioMode::LongRangeMode.addr()
-            | mode.addr())?;
+        self.write_register(
+            Register::RegOpMode.addr(),
+            RadioMode::LongRangeMode.addr() | mode.addr(),
+        )?;
 
         self.mode = mode;
         Ok(())
@@ -427,7 +449,10 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         let base = 1;
         let frf = (freq * (base << 19)) / 32;
         // write registers
-        self.write_register(Register::RegFrfMsb.addr(), ((frf & 0x00FF_0000) >> 16) as u8)?;
+        self.write_register(
+            Register::RegFrfMsb.addr(),
+            ((frf & 0x00FF_0000) >> 16) as u8,
+        )?;
         self.write_register(Register::RegFrfMid.addr(), ((frf & 0x0000_FF00) >> 8) as u8)?;
         self.write_register(Register::RegFrfLsb.addr(), (frf & 0x0000_00FF) as u8)
     }
@@ -435,7 +460,7 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Sets the radio to use an explicit header. Default state is `ON`.
     fn set_explicit_header_mode(&mut self) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         let reg_modem_config_1 = self.read_register(Register::RegModemConfig1.addr())?;
-        self.write_register(Register::RegModemConfig1.addr(),reg_modem_config_1  & 0xfe)?;
+        self.write_register(Register::RegModemConfig1.addr(), reg_modem_config_1 & 0xfe)?;
         self.explicit_header = true;
         Ok(())
     }
@@ -443,16 +468,18 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Sets the radio to use an implicit header. Default state is `OFF`.
     fn set_implicit_header_mode(&mut self) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         let reg_modem_config_1 = self.read_register(Register::RegModemConfig1.addr())?;
-        self.write_register(Register::RegModemConfig1.addr(),reg_modem_config_1  & 0x01)?;
+        self.write_register(Register::RegModemConfig1.addr(), reg_modem_config_1 & 0x01)?;
         self.explicit_header = false;
         Ok(())
     }
 
-
     /// Sets the spreading factor of the radio. Supported values are between 6 and 12.
     /// If a spreading factor of 6 is set, implicit header mode must be used to transmit
     /// and receive packets. Default value is `7`.
-    pub fn set_spreading_factor(&mut self, mut sf: u8) -> Result<(), Error<E, CS::Error, RESET::Error>> {
+    pub fn set_spreading_factor(
+        &mut self,
+        mut sf: u8,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if sf < 6 {
             sf = 6;
         } else if sf > 12 {
@@ -467,8 +494,10 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
             self.write_register(Register::RegDetectionThreshold.addr(), 0x0a)?;
         }
         let modem_config_2 = self.read_register(Register::RegModemConfig2.addr())?;
-        self.write_register(Register::RegModemConfig2.addr(), (modem_config_2 & 0x0f)
-            | ((sf << 4) & 0xf0))?;
+        self.write_register(
+            Register::RegModemConfig2.addr(),
+            (modem_config_2 & 0x0f) | ((sf << 4) & 0xf0),
+        )?;
         self.set_ldo_flag()?;
         Ok(())
     }
@@ -476,7 +505,10 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Sets the signal bandwidth of the radio. Supported values are: `7800 Hz`, `10400 Hz`,
     /// `15600 Hz`, `20800 Hz`, `31250 Hz`,`41700 Hz` ,`62500 Hz`,`125000 Hz` and `250000 Hz`
     /// Default value is `125000 Hz`
-    pub fn set_signal_bandwidth(&mut self, sbw: i64) -> Result<(), Error<E, CS::Error, RESET::Error>> {
+    pub fn set_signal_bandwidth(
+        &mut self,
+        sbw: i64,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         let bw: i64;
         match sbw {
             7_800 => bw = 0,
@@ -491,8 +523,10 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
             _ => bw = 9,
         }
         let modem_config_1 = self.read_register(Register::RegModemConfig1.addr())?;
-        self.write_register(Register::RegModemConfig1.addr(), (modem_config_1 & 0x0f)
-            | ((bw << 4) as u8))?;
+        self.write_register(
+            Register::RegModemConfig1.addr(),
+            (modem_config_1 & 0x0f) | ((bw << 4) as u8),
+        )?;
         self.set_ldo_flag()?;
         Ok(())
     }
@@ -500,7 +534,10 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Sets the coding rate of the radio with the numerator fixed at 4. Supported values
     /// are between `5` and `8`, these correspond to coding rates of `4/5` and `4/8`.
     /// Default value is `5`.
-    pub fn set_coding_rate_4(&mut self, mut denominator: u8) -> Result<(), Error<E, CS::Error, RESET::Error>> {
+    pub fn set_coding_rate_4(
+        &mut self,
+        mut denominator: u8,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if denominator < 5 {
             denominator = 5;
         } else if denominator > 8 {
@@ -508,13 +545,18 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         }
         let cr = denominator - 4;
         let modem_config_1 = self.read_register(Register::RegModemConfig1.addr())?;
-        self.write_register( Register::RegModemConfig1.addr(), (modem_config_1 & 0xf1)
-            | (cr << 1))
+        self.write_register(
+            Register::RegModemConfig1.addr(),
+            (modem_config_1 & 0xf1) | (cr << 1),
+        )
     }
 
     /// Sets the preamble length of the radio. Values are between 6 and 65535.
     /// Default value is `8`.
-    pub fn set_preamble_length(&mut self, length: i64) -> Result<(), Error<E, CS::Error, RESET::Error>> {
+    pub fn set_preamble_length(
+        &mut self,
+        length: i64,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         self.write_register(Register::RegPreambleMsb.addr(), (length >> 8) as u8)?;
         self.write_register(Register::RegPreambleLsb.addr(), length as u8)
     }
@@ -524,7 +566,7 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         let modem_config_2 = self.read_register(Register::RegModemConfig2.addr())?;
         if value {
             self.write_register(Register::RegModemConfig2.addr(), modem_config_2 | 0x04)
-        }else{
+        } else {
             self.write_register(Register::RegModemConfig2.addr(), modem_config_2 & 0xfb)
         }
     }
@@ -532,14 +574,13 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     /// Inverts the radio's IQ signals. Default value is `false`.
     pub fn set_invert_iq(&mut self, value: bool) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         if value {
-            self.write_register(Register::RegInvertiq.addr(),  0x66)?;
+            self.write_register(Register::RegInvertiq.addr(), 0x66)?;
             self.write_register(Register::RegInvertiq2.addr(), 0x19)
-        }else{
-            self.write_register(Register::RegInvertiq.addr(),  0x27)?;
+        } else {
+            self.write_register(Register::RegInvertiq.addr(), 0x27)?;
             self.write_register(Register::RegInvertiq2.addr(), 0x1d)
         }
     }
-
 
     /// Returns the spreading factor of the radio.
     pub fn get_spreading_factor(&mut self) -> Result<u8, Error<E, CS::Error, RESET::Error>> {
@@ -572,38 +613,40 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
 
     /// Returns the signal to noise radio of the the last received packet.
     pub fn get_packet_snr(&mut self) -> Result<f64, Error<E, CS::Error, RESET::Error>> {
-        Ok(f64::from(self.read_register(Register::RegPktSnrValue.addr())?))
+        Ok(f64::from(
+            self.read_register(Register::RegPktSnrValue.addr())?,
+        ))
     }
 
     /// Returns the frequency error of the last received packet in Hz.
     pub fn get_packet_frequency_error(&mut self) -> Result<i64, Error<E, CS::Error, RESET::Error>> {
         let mut freq_error: i32 = 0;
-        freq_error = i32::from(self.read_register( Register::RegFreqErrorMsb.addr())? & 0x7);
+        freq_error = i32::from(self.read_register(Register::RegFreqErrorMsb.addr())? & 0x7);
         freq_error <<= 8i64;
         freq_error += i32::from(self.read_register(Register::RegFreqErrorMid.addr())?);
         freq_error <<= 8i64;
-        freq_error += i32::from(self.read_register( Register::RegFreqErrorLsb.addr())?);
+        freq_error += i32::from(self.read_register(Register::RegFreqErrorLsb.addr())?);
 
         let f_xtal = 32_000_000; // FXOSC: crystal oscillator (XTAL) frequency (2.5. Chip Specification, p. 14)
-        let f_error = ((f64::from(freq_error) * (1i64 << 24) as f64) / f64::from(f_xtal)) *
-            (self.get_signal_bandwidth()? as f64 / 500_000.0f64); // p. 37
+        let f_error = ((f64::from(freq_error) * (1i64 << 24) as f64) / f64::from(f_xtal))
+            * (self.get_signal_bandwidth()? as f64 / 500_000.0f64); // p. 37
         Ok(f_error as i64)
     }
 
     fn set_ldo_flag(&mut self) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         let sw = self.get_signal_bandwidth()?;
         // Section 4.1.1.5
-        let symbol_duration = 1000 / (sw / ((1 as i64) << self.get_spreading_factor()?)) ;
+        let symbol_duration = 1000 / (sw / ((1 as i64) << self.get_spreading_factor()?));
 
         // Section 4.1.1.6
         let ldo_on = symbol_duration > 16;
 
         let mut config_3 = self.read_register(Register::RegModemConfig3.addr())?;
-        config_3.set_bit(3,ldo_on);
+        config_3.set_bit(3, ldo_on);
         self.write_register(Register::RegModemConfig3.addr(), config_3)
     }
 
-    fn read_register(&mut self, reg: u8) -> Result<u8,Error<E, CS::Error, RESET::Error>> {
+    fn read_register(&mut self, reg: u8) -> Result<u8, Error<E, CS::Error, RESET::Error>> {
         self.cs.set_low().map_err(CS)?;
 
         let mut buffer = [reg & 0x7f, 0];
@@ -612,18 +655,22 @@ impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
         Ok(transfer[1])
     }
 
-    fn write_register(&mut self, reg: u8, byte: u8) -> Result<(),Error<E, CS::Error, RESET::Error>>{
+    fn write_register(
+        &mut self,
+        reg: u8,
+        byte: u8,
+    ) -> Result<(), Error<E, CS::Error, RESET::Error>> {
         self.cs.set_low().map_err(CS)?;
 
         let buffer = [reg | 0x80, byte];
-        let write = self.spi.write(& buffer).map_err(SPI)?;
+        self.spi.write(&buffer).map_err(SPI)?;
         self.cs.set_high().map_err(CS)?;
-        Ok(write)
+        Ok(())
     }
 }
 /// Modes of the radio and their corresponding register values.
 #[derive(Clone, Copy)]
-pub enum RadioMode{
+pub enum RadioMode {
     LongRangeMode = 0x80,
     Sleep = 0x00,
     Stdby = 0x01,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,11 +163,11 @@ pub const MODE: Mode = Mode {
 };
 
 /// Provides high-level access to Semtech SX1276/77/78/79 based boards connected to a Raspberry Pi
-pub struct LoRa<SPI, CS, RESET, DELAY> {
-    spi: SPI,
+pub struct LoRa<'a, SPI, CS, RESET, DELAY> {
+    spi: &'a mut SPI,
     cs: CS,
     reset: RESET,
-    delay: DELAY,
+    delay: &'a mut DELAY,
     frequency: i64,
     pub explicit_header: bool,
     pub mode: RadioMode,
@@ -186,12 +186,12 @@ pub enum Error<SPI, CS, RESET> {
 use Error::*;
 
 
-impl<SPI, CS, RESET, DELAY, E> LoRa<SPI, CS, RESET, DELAY>
+impl<'a, SPI, CS, RESET, DELAY, E> LoRa<'a, SPI, CS, RESET, DELAY>
     where SPI: Transfer<u8, Error = E> + Write<u8, Error = E>,
           CS: OutputPin, RESET: OutputPin, DELAY: DelayMs<u8>{
     /// Builds and returns a new instance of the radio. Only one instance of the radio should exist at a time.
     /// This also preforms a hardware reset of the module and then puts it in standby.
-    pub fn new(spi: SPI, cs: CS, reset: RESET, frequency: i64, delay: DELAY)
+    pub fn new(spi: &'a mut SPI, cs: CS, reset: RESET, frequency: i64, delay: &'a mut DELAY)
                -> Result<Self, Error<E, CS::Error, RESET::Error>> {
 
         let mut sx127x = LoRa {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,11 @@ pub enum Error<SPI, CS, RESET> {
 
 use Error::*;
 
+#[cfg(not(feature = "version_0x09"))]
+const VERSION_CHECK: u8 = 0x12;
+
+#[cfg(feature = "version_0x09")]
+const VERSION_CHECK: u8 = 0x09;
 
 impl<'a, SPI, CS, RESET, DELAY, E> LoRa<'a, SPI, CS, RESET, DELAY>
     where SPI: Transfer<u8, Error = E> + Write<u8, Error = E>,
@@ -208,7 +213,7 @@ impl<'a, SPI, CS, RESET, DELAY, E> LoRa<'a, SPI, CS, RESET, DELAY>
         sx127x.reset.set_high().map_err(Reset)?;
         sx127x.delay.delay_ms(10);
         let version = sx127x.read_register(Register::RegVersion.addr())?;
-        if version == 0x12 {
+        if version == VERSION_CHECK {
             sx127x.set_mode(RadioMode::Sleep)?;
             sx127x.set_frequency(frequency)?;
             sx127x.write_register(Register::RegFifoTxBaseAddr.addr(),0)?;
@@ -219,7 +224,7 @@ impl<'a, SPI, CS, RESET, DELAY, E> LoRa<'a, SPI, CS, RESET, DELAY>
             sx127x.set_mode(RadioMode::Stdby)?;
             sx127x.cs.set_high().map_err(CS)?;
             Ok(sx127x)
-        }else{
+        } else {
             Err(Error::VersionMismatch(version))
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ pub const MODE: Mode = Mode {
 };
 
 /// Provides high-level access to Semtech SX1276/77/78/79 based boards connected to a Raspberry Pi
-pub struct LoRa<'a, SPI, CS, RESET> {
-    spi: &'a mut SPI,
+pub struct LoRa<SPI, CS, RESET> {
+    spi: SPI,
     cs: CS,
     reset: RESET,
     frequency: i64,
@@ -190,12 +190,12 @@ const VERSION_CHECK: u8 = 0x12;
 #[cfg(feature = "version_0x09")]
 const VERSION_CHECK: u8 = 0x09;
 
-impl<'a, SPI, CS, RESET, E> LoRa<'a, SPI, CS, RESET>
+impl<SPI, CS, RESET, E> LoRa<SPI, CS, RESET>
     where SPI: Transfer<u8, Error = E> + Write<u8, Error = E>,
           CS: OutputPin, RESET: OutputPin {
     /// Builds and returns a new instance of the radio. Only one instance of the radio should exist at a time.
     /// This also preforms a hardware reset of the module and then puts it in standby.
-    pub fn new(spi: &'a mut SPI, cs: CS, reset: RESET, frequency: i64, delay: &mut dyn DelayMs<u8>)
+    pub fn new(spi: SPI, cs: CS, reset: RESET, frequency: i64, delay: &mut dyn DelayMs<u8>)
                -> Result<Self, Error<E, CS::Error, RESET::Error>> {
 
         let mut sx127x = LoRa {

--- a/src/register.rs
+++ b/src/register.rs
@@ -38,13 +38,13 @@ pub enum Register {
     RegPaDac = 0x4d,
 }
 #[derive(Clone, Copy)]
-pub enum PaConfig{
+pub enum PaConfig {
     PaBoost = 0x80,
     PaOutputRfoPin = 0,
 }
 
 #[derive(Clone, Copy)]
-pub enum IRQ{
+pub enum IRQ {
     IrqTxDoneMask = 0x08,
     IrqPayloadCrcErrorMask = 0x20,
     IrqRxDoneMask = 0x40,

--- a/src/register.rs
+++ b/src/register.rs
@@ -8,6 +8,7 @@ pub enum Register {
     RegFrfMid = 0x07,
     RegFrfLsb = 0x08,
     RegPaConfig = 0x09,
+    RegPaRamp = 0x0a,
     RegOcp = 0x0b,
     RegLna = 0x0c,
     RegFifoAddrPtr = 0x0d,
@@ -66,4 +67,32 @@ impl IRQ {
     pub fn addr(self) -> u8 {
         self as u8
     }
+}
+
+#[derive(Clone, Copy)]
+pub enum FskDataModulationShaping {
+    None = 1,
+    GaussianBt1d0 = 2,
+    GaussianBt0d5 = 10,
+    GaussianBt0d3 = 11
+}
+
+#[derive(Clone, Copy)]
+pub enum FskRampUpRamDown {
+    _3d4ms = 0b000,
+    _2ms = 0b0001,
+    _1ms = 0b0010,
+    _500us = 0b0011,
+    _250us = 0b0100,
+    _125us = 0b0101,
+    _100us = 0b0110,
+    _62us = 0b0111,
+    _50us = 0b1000,
+    _40us = 0b1001,
+    _31us = 0b1010,
+    _25us = 0b1011,
+    _20us = 0b1100,
+    _15us = 0b1101,
+    _12us = 0b1110,
+    _10us = 0b1111
 }


### PR DESCRIPTION
This PR seems huge because I've `cargo clippy` and `cargo fmt` -ed it, so it is smaller than it looks like.

This PR removes the delay from the main struct so that it is not "borrowed" forever in the driver. This helps when you're busy with an embedded platform where delay drivers are few.