### PR TITLE
Take slice as parameter in transmit_payload instead of a fixed-length buffer and a size

### DIFF
--- a/examples/pi_simple_send.rs
+++ b/examples/pi_simple_send.rs
@@ -35,15 +35,11 @@ fn main(){
 
     lora.set_tx_power(17,1); //Using PA_BOOST. See your board for correct pin.
 
-    let message = "Hello, world!";
-    let mut buffer = [0;255];
-    for (i,c) in message.chars().enumerate() {
-        buffer[i] = c as u8;
-    }
+    let message = b"Hello, world!";
 
-    let transmit = lora.transmit_payload(buffer,message.len());
+    let transmit = lora.transmit_payload(message);
     match transmit {
-        Ok(packet_size) => println!("Sent packet with size: {}", packet_size),
-        Err(()) => println!("Error"),
+        Ok(_) => println!("Sent packet"),
+        Err(e) => println!("Error: {:?}", e),
     }
 }

--- a/examples/pi_simple_send.rs
+++ b/examples/pi_simple_send.rs
@@ -17,7 +17,7 @@ fn main(){
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(20_000)
-        .mode(spidev::SPI_MODE_0)
+        .mode(spidev::SpiModeFlags::SPI_MODE_0)
         .build();
     spi.configure(&options).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl<SPI, CS, RESET, DELAY, E> LoRa<SPI, CS, RESET, DELAY>
         self.write_register(Register::RegDioMapping1.addr(), 0b01_00_00_00)
     }
 
-    pub fn transmit_payload(&mut self, buffer: [u8; 255], payload_size: usize)
+    pub fn transmit_payload(&mut self, payload: &[u8])
                             -> Result<(),Error<E, CS::Error, RESET::Error>>{
         if self.transmitting()? {
             Err(Transmitting)
@@ -270,10 +270,10 @@ impl<SPI, CS, RESET, DELAY, E> LoRa<SPI, CS, RESET, DELAY>
             self.write_register(Register::RegIrqFlags.addr(), 0)?;
             self.write_register(Register::RegFifoAddrPtr.addr(), 0)?;
             self.write_register(Register::RegPayloadLength.addr(), 0)?;
-            for byte in buffer.iter().take(payload_size){
-                self.write_register(Register::RegFifo.addr(), *byte)?;
+            for &byte in payload.iter().take(255) {
+                self.write_register(Register::RegFifo.addr(), byte)?;
             }
-            self.write_register(Register::RegPayloadLength.addr(),payload_size as u8)?;
+            self.write_register(Register::RegPayloadLength.addr(),payload.len().min(255) as u8)?;
             self.set_mode(RadioMode::Tx)?;
             Ok(())
         }


### PR DESCRIPTION
This avoids some iteration and copying