### PR TITLE
Wait for FSTX -> TX state transition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,8 +351,9 @@ where
 
     /// Returns true if the radio is currently transmitting a packet.
     pub fn transmitting(&mut self) -> Result<bool, Error<E, CS::Error, RESET::Error>> {
-        if (self.read_register(Register::RegOpMode.addr())? & RadioMode::Tx.addr())
-            == RadioMode::Tx.addr()
+        let op_mode = self.read_register(Register::RegOpMode.addr())?;
+        if (op_mode & RadioMode::Tx.addr()) == RadioMode::Tx.addr()
+            || (op_mode & RadioMode::FsTx.addr()) == RadioMode::FsTx.addr()
         {
             Ok(true)
         } else {
@@ -697,6 +698,7 @@ pub enum RadioMode {
     LongRangeMode = 0x80,
     Sleep = 0x00,
     Stdby = 0x01,
+    FsTx = 0x02,
     Tx = 0x03,
     RxContinuous = 0x05,
     RxSingle = 0x06,


### PR DESCRIPTION
When checking in `transmitting` function it should return `true` even when `FSTX` mode detected (which will eventually change to `TX` and the transmission will happen).