### PR TITLE
Dio0 interrupt api + examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["embedded-hal-driver","lora","sx1276","radio"]
 description = "A platform-agnostic driver for Semtech SX1276/77/78/79 based boards."
+exclude = ["examples/*"]
 
 [dependencies]
 embedded-hal = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![](http://meritbadge.herokuapp.com/sx127x-lora)](https://crates.io/crates/sx127x-lora)
 ![](https://img.shields.io/hexpm/l/plug.svg)
 
- A platform-agnostic driver for Semtech SX1276/77/78/79 based boards. It supports any device that
+A platform-agnostic driver for Semtech SX1276/77/78/79 based boards. It supports any device that
 implements the `embedded-hal` traits. Devices are connected over SPI and require an extra GPIO pin for
 RESET. This crate works with any Semtech based board including:
  * Modtronix inAir4, inAir9, and inAir9B
@@ -10,14 +10,16 @@ RESET. This crate works with any Semtech based board including:
  * Adafruit RP2040 RFM95
 
 ## Interrupts
-The crate currently polls the IRQ register on the radio to determine if a new packet has arrived. This
-would be more efficient if instead an interrupt was connected to the module's DIO_0 pin. Once interrupt
-support is available in `embedded-hal`, then this will be added. It is possible to implement this function on a
-device-to-device basis by retrieving a packet with the `read_packet()` function.
+The library currently supports the `TxDone` and `RxDone` interrupts on the `DIO0` pin. Blocking (e.g. `poll_irq(...)`)
+and GPIO-interrupt-driven (e.g. `RxDone` on `DIO0`) approaches are available, and you can see examples of both in
+`examples/rp2040`.
+
+## Tests
+From the root dir: `$ cargo test`
 
 ## TODO
-* Implement DIO_0 interrupt
 * Add async support
+* Support additional interrupts (e.g. `RxTimeout` on `DIO1`)
 
 ## Contributing
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/examples/rp2040/Cargo.toml
+++ b/examples/rp2040/Cargo.toml
@@ -9,8 +9,8 @@ cortex-m-rt = "0.7.5"
 critical-section = "1.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-bus = "0.3.0"
-embedded-sdmmc = "0.9.0"
-panic-halt = "1.0.0"
 rp2040-hal = { version = "0.11.0", features = ["rt", "critical-section-impl"] }
 rp2040-boot2 = "0.3.0"
 sx127x_lora = { path = "../../" }
+usb-device = "0.3.2"
+usbd-serial = "0.2.2"

--- a/examples/rp2040/README.md
+++ b/examples/rp2040/README.md
@@ -6,5 +6,6 @@ The RP2040 examples are based upon an [Adafruit Feather RP2040 RFM95](https://ww
 
 From this directory:
 
-1. Attach RP2040 feather target to host machine in boot mode
-2. Flash firmware: `$ cargo run --example tx`
+1. Attach RP2040 feather target to host machine in boot mode.
+2. Flash firmware, e.g.: `$ cargo run --example tx`.
+3. View output via serial client on host, e.g.: `minicom -D /dev/ttyACM0 -b 115200`.

--- a/examples/rp2040/examples/rx.rs
+++ b/examples/rp2040/examples/rx.rs
@@ -1,6 +1,7 @@
 //! Receive packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
 //!
-//! This will blink the on-board LED when reception is successful. On failure, nop.
+//! This will blink the on-board LED if reception is successful. On failure, the on-board LED will
+//! be turned on.
 
 #![no_std]
 #![no_main]
@@ -73,10 +74,11 @@ fn main() -> ! {
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
 
-    let message = "hello, world!";
-    let mut buffer = [0;255];
-    for (i,c) in message.chars().enumerate() {
-        buffer[i] = c as u8;
+    {
+        led.set_high().unwrap();
+        timer.delay_ms(500);
+        led.set_low().unwrap();
+        timer.delay_ms(500);
     }
 
     loop {
@@ -89,7 +91,7 @@ fn main() -> ! {
                     timer.delay_ms(500);
                 }
             },
-            Err(_) => {}
+            Err(_) => led.set_high().unwrap()
         }
     }
 }

--- a/examples/rp2040/examples/rx.rs
+++ b/examples/rp2040/examples/rx.rs
@@ -1,7 +1,7 @@
-//! Receive packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
+//! Receive packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board.
 //!
-//! This will blink the on-board LED if reception is successful. On failure, the on-board LED will
-//! be turned on.
+//! Output is available via serial over a USB-C connection, and panics will turn the on-board LED
+//! on.
 
 #![no_std]
 #![no_main]
@@ -9,15 +9,75 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::ops::DerefMut;
+use core::panic::PanicInfo;
+use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
-use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
-use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullNone};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
+use rp2040_hal::fugit::RateExtU32;
+use rp2040_hal::gpio::bank0::Gpio13;
+use rp2040_hal::multicore::{Multicore, Stack};
+use rp2040_hal::pac::{PPB, PSM};
+use rp2040_hal::rtc::DateTime;
+use rp2040_hal::sio::SioFifo;
+use usb_device::class_prelude::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+use sx127x_lora::Sx127xError;
+use crate::SioFifoMsg::*;
+
+enum SioFifoMsg {
+    ErrReceiving = 0x0,
+    ErrReset = 0x1,
+    ErrSpi = 0x2,
+    ErrTransmitting = 0x3,
+    ErrUninformative = 0x4,
+    ErrVersionMismatch = 0x5,
+    PacketNotReady = 0x6,
+    RxOk = 0x7,
+    SetupDone = 0x8,
+    StartPolling = 0x9,
+}
+impl TryFrom<u32> for SioFifoMsg {
+    type Error = ();
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0 => Ok(ErrReceiving),
+            0x1 => Ok(ErrReset),
+            0x2 => Ok(ErrSpi),
+            0x3 => Ok(ErrTransmitting),
+            0x4 => Ok(ErrUninformative),
+            0x5 => Ok(ErrVersionMismatch),
+            0x6 => Ok(PacketNotReady),
+            0x7 => Ok(RxOk),
+            0x8 => Ok(SetupDone),
+            0x9 => Ok(StartPolling),
+            _ => Err(())
+        }
+    }
+}
+
+impl From<SioFifoMsg> for &[u8] {
+    fn from(value: SioFifoMsg) -> Self {
+        match value {
+            ErrReceiving => "LoRa RX err: receiving\r\n",
+            ErrReset => "LoRa RX err: reset\r\n",
+            ErrSpi => "LoRa RX err: SPI\r\n",
+            ErrTransmitting => "LoRa RX err: transmitting\r\n",
+            ErrUninformative => "LoRa RX err: uninformative\r\n",
+            ErrVersionMismatch => "LoRa RX err: version mismatch\r\n",
+            PacketNotReady => "LoRa RX: packet not ready\r\n",
+            RxOk => "LoRa RX ok\r\n",
+            SetupDone => "LoRa RX: setup done\r\n",
+            StartPolling => "LoRa RX: start polling\r\n",
+        }.as_bytes()
+    }
+}
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -26,12 +86,26 @@ use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
 #[used]
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
+/// Stack for core 1
+///
+/// Core 0 gets its stack via the normal route - any memory not used by static values is
+/// reserved for stack and initialised by cortex-m-rt.
+/// To get the same for Core 1, we would need to compile everything separately and
+/// modify the linker file for both programs, and that's quite annoying.
+/// So instead, core1.spawn takes a [usize] which gets used for the stack.
+/// NOTE: We use the `Stack` struct here to ensure that it has 32-byte alignment, which allows
+/// the stack guard to take up the least amount of usable RAM.
+static CORE1_STACK: Stack<4096> = Stack::new();
+
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
 
-#[rp2040_hal::entry]
-fn main() -> ! {
-    let mut pac = pac::Peripherals::take().unwrap();
+static SIO_FIFO: Mutex<RefCell<Option<SioFifo>>> = Mutex::new(RefCell::new(None));
+static LED_PIN: Mutex<RefCell<Option<Pin<Gpio13, FunctionSioOutput, PullNone>>>> = Mutex::new(RefCell::new(None));
+
+fn core1_task(_sys_freq: u32) -> ! {
+    let mut pac = unsafe { pac::Peripherals::steal() };
+    let mut sio = Sio::new(pac.SIO);
     let mut watchdog = Watchdog::new(pac.WATCHDOG);
 
     let clocks = init_clocks_and_plls(
@@ -45,14 +119,101 @@ fn main() -> ! {
     )
         .ok()
         .unwrap();
-    let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
-    let sio = Sio::new(pac.SIO);
+
+    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
+        pac.USBCTRL_REGS,
+        pac.USBCTRL_DPRAM,
+        clocks.usb_clock,
+        true,
+        &mut pac.RESETS,
+    ));
+    let mut serial = SerialPort::new(&usb_bus);
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Raspberry Pi")
+            .product("RP2 USB Serial")
+            .serial_number("E0C9125B0D9B")])
+        .unwrap()
+        .device_class(USB_CLASS_CDC) // from: https://www.usb.org/defined-class-codes
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+        match sio.fifo.read() {
+            Some(word) => {
+                if let Ok(msg) = SioFifoMsg::try_from(word) {
+                    serial.write(msg.into()).unwrap();
+                } else {
+                    serial.write("Unexpected msg\r\n".as_bytes()).unwrap();
+                }
+            },
+            None => continue,
+        }
+    }
+}
+
+fn init_core_1(psm: &mut PSM, ppb: &mut PPB, fifo: &mut SioFifo, clk_freq: u32, ) {
+    let mut mc = Multicore::new(psm, ppb, fifo);
+    let cores = mc.cores();
+    let core1 = &mut cores[1];
+    let sys_freq = clk_freq;
+    let _ = core1.spawn(CORE1_STACK.take().unwrap(), move || core1_task(sys_freq));
+}
+
+#[rp2040_hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let mut sio = Sio::new(pac.SIO);
+
     let pins = Pins::new(
         pac.IO_BANK0,
         pac.PADS_BANK0,
         sio.gpio_bank0,
         &mut pac.RESETS,
     );
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+        .ok()
+        .unwrap();
+    let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+    let mut rtc = hal::rtc::RealTimeClock::new(
+        pac.RTC,
+        clocks.rtc_clock,
+        &mut pac.RESETS,
+        DateTime {
+            year: 0,
+            month: 1,
+            day: 1,
+            day_of_week: hal::rtc::DayOfWeek::Monday,
+            hour: 0,
+            minute: 0,
+            second: 0,
+        },
+    )
+        .unwrap();
+    rtc.now().unwrap();
+
+    init_core_1(
+        &mut pac.PSM,
+        &mut pac.PPB,
+        &mut sio.fifo,
+        clocks.system_clock.freq().to_Hz()
+    );
+
+    critical_section::with(|cs| {
+        SIO_FIFO.borrow(cs).replace(Some(sio.fifo));
+    });
 
     let spi_mosi = pins.gpio15.into_function::<hal::gpio::FunctionSpi>();
     let spi_miso = pins.gpio8.into_function::<hal::gpio::FunctionSpi>();
@@ -66,32 +227,61 @@ fn main() -> ! {
     );
     let spi_bus = RefCell::new(spi);
 
-    let mut led: Pin<_, FunctionSioOutput, PullDown> = pins.gpio13.reconfigure();
-
     let nss = pins.gpio16.into_push_pull_output_in_state(PinState::High);
     let reset = pins.gpio17.into_push_pull_output_in_state(PinState::High);
 
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
 
-    {
-        led.set_high().unwrap();
-        timer.delay_ms(500);
-        led.set_low().unwrap();
-        timer.delay_ms(500);
-    }
+    timer.delay_ms(1000);
+    send_sio_fifo_msg(SetupDone);
 
     loop {
-        match lora.poll_irq(Some(30)) { // 30 millisecond timeout
+        send_sio_fifo_msg(StartPolling);
+        let msg = match lora.poll_irq(None) {
             Ok(_) => {
-                for _ in 0..3 {
-                    led.set_high().unwrap();
-                    timer.delay_ms(500);
-                    led.set_low().unwrap();
-                    timer.delay_ms(500);
+                // TODO handle packet_size > 255
+                match lora.read_packet() {
+                    Ok(_) => RxOk,
+                    Err(e) => match e {
+                        Sx127xError::Uninformative => ErrUninformative,
+                        Sx127xError::VersionMismatch(_) => ErrVersionMismatch,
+                        Sx127xError::Reset(_) => ErrReset,
+                        Sx127xError::SPI(_) => ErrSpi,
+                        Sx127xError::Transmitting => ErrTransmitting,
+                        Sx127xError::Receiving => ErrReceiving,
+                    },
                 }
             },
-            Err(_) => led.set_high().unwrap()
-        }
+            Err(e) => match e {
+                Sx127xError::Uninformative => ErrUninformative,
+                Sx127xError::VersionMismatch(_) => ErrVersionMismatch,
+                Sx127xError::Reset(_) => ErrReset,
+                Sx127xError::SPI(_) => ErrSpi,
+                Sx127xError::Transmitting => ErrTransmitting,
+                Sx127xError::Receiving => ErrReceiving,
+            },
+        };
+        send_sio_fifo_msg(msg);
     }
+}
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    critical_section::with(|cs| {
+        let mut maybe_led = LED_PIN.borrow(cs).borrow_mut();
+        if let Some(led) = maybe_led.deref_mut() {
+            led.set_high().unwrap();
+        }
+    });
+    loop {}
+}
+
+fn send_sio_fifo_msg(msg: SioFifoMsg) {
+    critical_section::with(|cs| {
+        let mut maybe_sio_fifo = SIO_FIFO.borrow_ref_mut(cs);
+        if let Some(sio_fifo) = maybe_sio_fifo.as_mut() {
+            sio_fifo.write(msg as u32);
+        }
+    });
 }

--- a/examples/rp2040/examples/rx_interrupt.rs
+++ b/examples/rp2040/examples/rx_interrupt.rs
@@ -1,7 +1,7 @@
-//! Transmit packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
+//! Receive packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board.
 //!
-//! This will blink the on-board LED if transmission is successful. On failure, the on-board LED
-//! will be turned on.
+//! This will trigger the RxDone interrupt on DIO0 if successful and blink the on-board LED. On
+//! failure, the on-board LED will be turned on.
 
 #![no_std]
 #![no_main]
@@ -9,6 +9,9 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::sync::atomic::{AtomicBool, Ordering};
+use cortex_m::asm::wfi;
+use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
@@ -16,8 +19,12 @@ use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
 use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
+use rp2040_hal::gpio::bank0::Gpio21;
+use rp2040_hal::gpio::Interrupt::EdgeHigh;
+use rp2040_hal::pac::interrupt;
+use sx127x_lora::{Interrupt, RadioMode};
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -28,6 +35,11 @@ pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
+
+type Dio0 = Pin<Gpio21, FunctionSioInput, PullDown>;
+
+static DIO0: Mutex<RefCell<Option<Dio0>>> = Mutex::new(RefCell::new(None));
+static DIO0_FLAG: AtomicBool = AtomicBool::new(false);
 
 #[rp2040_hal::entry]
 fn main() -> ! {
@@ -67,31 +79,51 @@ fn main() -> ! {
     let spi_bus = RefCell::new(spi);
 
     let mut led: Pin<_, FunctionSioOutput, PullDown> = pins.gpio13.reconfigure();
-
     let nss = pins.gpio16.into_push_pull_output_in_state(PinState::High);
     let reset = pins.gpio17.into_push_pull_output_in_state(PinState::High);
 
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
 
-    let message = "hello, world!";
-    let mut buffer = [0;255];
-    for (i,c) in message.chars().enumerate() {
-        buffer[i] = c as u8;
+    let dio0: Pin<Gpio21, FunctionSioInput, PullDown> = pins.gpio21.reconfigure();
+    dio0.set_interrupt_enabled(EdgeHigh, true);
+
+    critical_section::with(|cs| {
+        DIO0.borrow(cs).replace(Some(dio0));
+    });
+
+    lora.enable_interrupt(Interrupt::RxDone).unwrap();
+    lora.set_mode(RadioMode::RxContinuous).unwrap();
+    unsafe {
+        pac::NVIC::unmask(pac::Interrupt::IO_IRQ_BANK0);
     }
 
     loop {
-        match lora.transmit_payload(&buffer) {
-            Ok(_) => {
-                for _ in 0..3 {
+        if DIO0_FLAG.load(Ordering::Relaxed) {
+            lora.clear_interrupt(Interrupt::RxDone).unwrap();
+            match lora.read_packet() {
+                Ok(_) => {
                     led.set_high().unwrap();
                     timer.delay_ms(500);
                     led.set_low().unwrap();
                     timer.delay_ms(500);
                 }
-            },
-            Err(_) => {}
+                Err(_) => led.set_high().unwrap()
+            }
+            DIO0_FLAG.store(false, Ordering::Relaxed);
         }
-        timer.delay_ms(5000);
+
+        wfi();
     }
+}
+
+#[interrupt]
+fn IO_IRQ_BANK0() {
+    critical_section::with(|cs| {
+        let mut maybe_dio0 = DIO0.borrow(cs).borrow_mut();
+        if let Some(dio0) = maybe_dio0.as_mut() {
+            DIO0_FLAG.store(true, Ordering::Relaxed);
+            dio0.clear_interrupt(EdgeHigh);
+        }
+    })
 }

--- a/examples/rp2040/examples/rx_interrupt.rs
+++ b/examples/rp2040/examples/rx_interrupt.rs
@@ -1,7 +1,11 @@
-//! Receive packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board.
+//! Receive packets via interrupt using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95
+//! board.
 //!
-//! This will trigger the RxDone interrupt on DIO0 if successful and blink the on-board LED. On
-//! failure, the on-board LED will be turned on.
+//! The chip will trigger the RxDone interrupt on DIO0 if receive was successful. Output is
+//! available via serial over a USB-C connection, and panics will turn the on-board LED on.
+//!
+//! Note that the `RxDone` interrupt does not need to explicitly cleared by app code, as
+//! `read_packet()` will do so.
 
 #![no_std]
 #![no_main]
@@ -9,22 +13,75 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::ops::DerefMut;
+use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicBool, Ordering};
 use cortex_m::asm::wfi;
 use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
-use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
 use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown, PullNone};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
-use rp2040_hal::gpio::bank0::Gpio21;
+use rp2040_hal::gpio::bank0::{Gpio13, Gpio21};
 use rp2040_hal::gpio::Interrupt::EdgeHigh;
-use rp2040_hal::pac::interrupt;
-use sx127x_lora::{Interrupt, RadioMode};
+use rp2040_hal::multicore::{Multicore, Stack};
+use rp2040_hal::pac::{interrupt, PPB, PSM};
+use rp2040_hal::sio::SioFifo;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::device::{StringDescriptors, UsbDeviceBuilder, UsbVidPid};
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+use sx127x_lora::{Interrupt, Sx127xError};
+use sx127x_lora::RadioMode::RxContinuous;
+use crate::SioFifoMsg::*;
+
+enum SioFifoMsg {
+    ErrReceiving = 0x0,
+    ErrReset = 0x1,
+    ErrSpi = 0x2,
+    ErrTransmitting = 0x3,
+    ErrUninformative = 0x4,
+    ErrVersionMismatch = 0x5,
+    PacketNotReady = 0x6,
+    RxOk = 0x7,
+    SetupDone = 0x8,
+}
+impl TryFrom<u32> for SioFifoMsg {
+    type Error = ();
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0 => Ok(ErrReceiving),
+            0x1 => Ok(ErrReset),
+            0x2 => Ok(ErrSpi),
+            0x3 => Ok(ErrTransmitting),
+            0x4 => Ok(ErrUninformative),
+            0x5 => Ok(ErrVersionMismatch),
+            0x6 => Ok(PacketNotReady),
+            0x7 => Ok(RxOk),
+            0x8 => Ok(SetupDone),
+            _ => Err(())
+        }
+    }
+}
+
+impl From<SioFifoMsg> for &[u8] {
+    fn from(value: SioFifoMsg) -> Self {
+        match value {
+            ErrReceiving => "LoRa RX err: receiving\r\n",
+            ErrReset => "LoRa RX err: reset\r\n",
+            ErrSpi => "LoRa RX err: SPI\r\n",
+            ErrTransmitting => "LoRa RX err: transmitting\r\n",
+            ErrUninformative => "LoRa RX err: uninformative\r\n",
+            ErrVersionMismatch => "LoRa RX err: version mismatch\r\n",
+            PacketNotReady => "LoRa RX: packet not ready\r\n",
+            RxOk => "LoRa RX ok\r\n",
+            SetupDone => "LoRa RX: setup done\r\n",
+        }.as_bytes()
+    }
+}
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -33,6 +90,17 @@ use sx127x_lora::{Interrupt, RadioMode};
 #[used]
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
+/// Stack for core 1
+///
+/// Core 0 gets its stack via the normal route - any memory not used by static values is
+/// reserved for stack and initialised by cortex-m-rt.
+/// To get the same for Core 1, we would need to compile everything separately and
+/// modify the linker file for both programs, and that's quite annoying.
+/// So instead, core1.spawn takes a [usize] which gets used for the stack.
+/// NOTE: We use the `Stack` struct here to ensure that it has 32-byte alignment, which allows
+/// the stack guard to take up the least amount of usable RAM.
+static CORE1_STACK: Stack<4096> = Stack::new();
+
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
 
@@ -40,10 +108,12 @@ type Dio0 = Pin<Gpio21, FunctionSioInput, PullDown>;
 
 static DIO0: Mutex<RefCell<Option<Dio0>>> = Mutex::new(RefCell::new(None));
 static DIO0_FLAG: AtomicBool = AtomicBool::new(false);
+static LED_PIN: Mutex<RefCell<Option<Pin<Gpio13, FunctionSioOutput, PullNone>>>> = Mutex::new(RefCell::new(None));
+static SIO_FIFO: Mutex<RefCell<Option<SioFifo>>> = Mutex::new(RefCell::new(None));
 
-#[rp2040_hal::entry]
-fn main() -> ! {
-    let mut pac = pac::Peripherals::take().unwrap();
+fn core1_task(_sys_freq: u32) -> ! {
+    let mut pac = unsafe { pac::Peripherals::steal() };
+    let mut sio = Sio::new(pac.SIO);
     let mut watchdog = Watchdog::new(pac.WATCHDOG);
 
     let clocks = init_clocks_and_plls(
@@ -57,13 +127,79 @@ fn main() -> ! {
     )
         .ok()
         .unwrap();
+
+    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
+        pac.USBCTRL_REGS,
+        pac.USBCTRL_DPRAM,
+        clocks.usb_clock,
+        true,
+        &mut pac.RESETS,
+    ));
+    let mut serial = SerialPort::new(&usb_bus);
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Raspberry Pi")
+            .product("RP2 USB Serial")
+            .serial_number("E0C9125B0D9B")])
+        .unwrap()
+        .device_class(USB_CLASS_CDC) // from: https://www.usb.org/defined-class-codes
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+        match sio.fifo.read() {
+            Some(word) => {
+                if let Ok(msg) = SioFifoMsg::try_from(word) {
+                    serial.write(msg.into()).unwrap();
+                } else {
+                    serial.write("Unexpected msg\r\n".as_bytes()).unwrap();
+                }
+            },
+            None => continue,
+        }
+    }
+}
+
+fn init_core_1(psm: &mut PSM, ppb: &mut PPB, fifo: &mut SioFifo, clk_freq: u32) {
+    let mut mc = Multicore::new(psm, ppb, fifo);
+    let cores = mc.cores();
+    let core1 = &mut cores[1];
+    let sys_freq = clk_freq;
+    let _ = core1.spawn(CORE1_STACK.take().unwrap(), move || core1_task(sys_freq));
+}
+
+#[rp2040_hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let mut sio = Sio::new(pac.SIO);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+        .ok()
+        .unwrap();
     let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
-    let sio = Sio::new(pac.SIO);
     let pins = Pins::new(
         pac.IO_BANK0,
         pac.PADS_BANK0,
         sio.gpio_bank0,
         &mut pac.RESETS,
+    );
+
+    init_core_1(
+        &mut pac.PSM,
+        &mut pac.PPB,
+        &mut sio.fifo,
+        clocks.system_clock.freq().to_Hz()
     );
 
     let spi_mosi = pins.gpio15.into_function::<hal::gpio::FunctionSpi>();
@@ -78,41 +214,46 @@ fn main() -> ! {
     );
     let spi_bus = RefCell::new(spi);
 
-    let mut led: Pin<_, FunctionSioOutput, PullDown> = pins.gpio13.reconfigure();
     let nss = pins.gpio16.into_push_pull_output_in_state(PinState::High);
     let reset = pins.gpio17.into_push_pull_output_in_state(PinState::High);
 
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
+    lora.set_mode(RxContinuous).unwrap();
+    lora.enable_interrupt(Interrupt::RxDone).unwrap();
 
     let dio0: Pin<Gpio21, FunctionSioInput, PullDown> = pins.gpio21.reconfigure();
     dio0.set_interrupt_enabled(EdgeHigh, true);
 
     critical_section::with(|cs| {
         DIO0.borrow(cs).replace(Some(dio0));
+        SIO_FIFO.borrow(cs).replace(Some(sio.fifo));
+        LED_PIN.borrow(cs).replace(Some(pins.gpio13.reconfigure()));
     });
 
-    lora.enable_interrupt(Interrupt::RxDone).unwrap();
-    lora.set_mode(RadioMode::RxContinuous).unwrap();
+    timer.delay_ms(1000);
+    send_sio_fifo_msg(SetupDone);
+
     unsafe {
         pac::NVIC::unmask(pac::Interrupt::IO_IRQ_BANK0);
     }
 
     loop {
         if DIO0_FLAG.load(Ordering::Relaxed) {
-            lora.clear_interrupt(Interrupt::RxDone).unwrap();
-            match lora.read_packet() {
-                Ok(_) => {
-                    led.set_high().unwrap();
-                    timer.delay_ms(500);
-                    led.set_low().unwrap();
-                    timer.delay_ms(500);
-                }
-                Err(_) => led.set_high().unwrap()
-            }
             DIO0_FLAG.store(false, Ordering::Relaxed);
+            let msg = match lora.read_packet() {
+                Ok(_) => RxOk,
+                Err(e) => match e {
+                    Sx127xError::Uninformative => ErrUninformative,
+                    Sx127xError::VersionMismatch(_) => ErrVersionMismatch,
+                    Sx127xError::Reset(_) => ErrReset,
+                    Sx127xError::SPI(_) => ErrSpi,
+                    Sx127xError::Transmitting => ErrTransmitting,
+                    Sx127xError::Receiving => ErrReceiving,
+                },
+            };
+            send_sio_fifo_msg(msg);
         }
-
         wfi();
     }
 }
@@ -126,4 +267,24 @@ fn IO_IRQ_BANK0() {
             dio0.clear_interrupt(EdgeHigh);
         }
     })
+}
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    critical_section::with(|cs| {
+        let mut maybe_led = LED_PIN.borrow(cs).borrow_mut();
+        if let Some(led) = maybe_led.deref_mut() {
+            led.set_high().unwrap();
+        }
+    });
+    loop {}
+}
+
+fn send_sio_fifo_msg(msg: SioFifoMsg) {
+    critical_section::with(|cs| {
+        let mut maybe_sio_fifo = SIO_FIFO.borrow_ref_mut(cs);
+        if let Some(sio_fifo) = maybe_sio_fifo.as_mut() {
+            sio_fifo.write(msg as u32);
+        }
+    });
 }

--- a/examples/rp2040/examples/tx.rs
+++ b/examples/rp2040/examples/tx.rs
@@ -1,7 +1,7 @@
-//! Transmit packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
+//! Transmit packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board.
 //!
-//! This will blink the on-board LED if transmission is successful. On failure, the on-board LED
-//! will be turned on.
+//! Output is available via serial over a USB-C connection, and panics will turn the on-board LED
+//! on.
 
 #![no_std]
 #![no_main]
@@ -9,15 +9,68 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::ops::DerefMut;
+use core::panic::PanicInfo;
+use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
-use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
-use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullNone};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
+use rp2040_hal::fugit::RateExtU32;
+use rp2040_hal::gpio::bank0::Gpio13;
+use rp2040_hal::multicore::{Multicore, Stack};
+use rp2040_hal::pac::{PPB, PSM};
+use rp2040_hal::sio::SioFifo;
+use usb_device::class_prelude::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+use sx127x_lora::Sx127xError;
+use crate::SioFifoMsg::*;
+
+enum SioFifoMsg {
+    ErrReceiving = 0x0,
+    ErrReset = 0x1,
+    ErrSpi = 0x2,
+    ErrTransmitting = 0x3,
+    ErrUninformative = 0x4,
+    ErrVersionMismatch = 0x5,
+    PacketNotReady = 0x6,
+    TxOk = 0x7,
+}
+impl TryFrom<u32> for SioFifoMsg {
+    type Error = ();
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0 => Ok(ErrReceiving),
+            0x1 => Ok(ErrReset),
+            0x2 => Ok(ErrSpi),
+            0x3 => Ok(ErrTransmitting),
+            0x4 => Ok(ErrUninformative),
+            0x5 => Ok(ErrVersionMismatch),
+            0x6 => Ok(PacketNotReady),
+            0x7 => Ok(TxOk),
+            _ => Err(())
+        }
+    }
+}
+
+impl From<SioFifoMsg> for &[u8] {
+    fn from(value: SioFifoMsg) -> Self {
+        match value {
+            ErrReceiving => "LoRa TX err: receiving\r\n",
+            ErrReset => "LoRa TX err: reset\r\n",
+            ErrSpi => "LoRa TX err: SPI\r\n",
+            ErrTransmitting => "LoRa TX err: transmitting\r\n",
+            ErrUninformative => "LoRa TX err: uninformative\r\n",
+            ErrVersionMismatch => "LoRa TX err: version mismatch\r\n",
+            PacketNotReady => "LoRa TX: packet not ready\r\n",
+            TxOk => "LoRa TX ok\r\n",
+        }.as_bytes()
+    }
+}
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -26,12 +79,26 @@ use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
 #[used]
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
+/// Stack for core 1
+///
+/// Core 0 gets its stack via the normal route - any memory not used by static values is
+/// reserved for stack and initialised by cortex-m-rt.
+/// To get the same for Core 1, we would need to compile everything separately and
+/// modify the linker file for both programs, and that's quite annoying.
+/// So instead, core1.spawn takes a [usize] which gets used for the stack.
+/// NOTE: We use the `Stack` struct here to ensure that it has 32-byte alignment, which allows
+/// the stack guard to take up the least amount of usable RAM.
+static CORE1_STACK: Stack<4096> = Stack::new();
+
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
 
-#[rp2040_hal::entry]
-fn main() -> ! {
-    let mut pac = pac::Peripherals::take().unwrap();
+static SIO_FIFO: Mutex<RefCell<Option<SioFifo>>> = Mutex::new(RefCell::new(None));
+static LED_PIN: Mutex<RefCell<Option<Pin<Gpio13, FunctionSioOutput, PullNone>>>> = Mutex::new(RefCell::new(None));
+
+fn core1_task(_sys_freq: u32) -> ! {
+    let mut pac = unsafe { pac::Peripherals::steal() };
+    let mut sio = Sio::new(pac.SIO);
     let mut watchdog = Watchdog::new(pac.WATCHDOG);
 
     let clocks = init_clocks_and_plls(
@@ -45,14 +112,86 @@ fn main() -> ! {
     )
         .ok()
         .unwrap();
-    let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
-    let sio = Sio::new(pac.SIO);
+
+    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
+        pac.USBCTRL_REGS,
+        pac.USBCTRL_DPRAM,
+        clocks.usb_clock,
+        true,
+        &mut pac.RESETS,
+    ));
+    let mut serial = SerialPort::new(&usb_bus);
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Raspberry Pi")
+            .product("RP2 USB Serial")
+            .serial_number("E0C9125B0D9B")])
+        .unwrap()
+        .device_class(USB_CLASS_CDC) // from: https://www.usb.org/defined-class-codes
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+        match sio.fifo.read() {
+            Some(word) => {
+                if let Ok(msg) = SioFifoMsg::try_from(word) {
+                    serial.write(msg.into()).unwrap();
+                } else {
+                    serial.write("Unexpected msg\r\n".as_bytes()).unwrap();
+                }
+            },
+            None => continue,
+        }
+    }
+}
+
+fn init_core_1(psm: &mut PSM, ppb: &mut PPB, fifo: &mut SioFifo, clk_freq: u32) {
+    let mut mc = Multicore::new(psm, ppb, fifo);
+    let cores = mc.cores();
+    let core1 = &mut cores[1];
+    let sys_freq = clk_freq;
+    let _ = core1.spawn(CORE1_STACK.take().unwrap(), move || core1_task(sys_freq));
+}
+
+#[rp2040_hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let mut sio = Sio::new(pac.SIO);
+
     let pins = Pins::new(
         pac.IO_BANK0,
         pac.PADS_BANK0,
         sio.gpio_bank0,
         &mut pac.RESETS,
     );
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+        .ok()
+        .unwrap();
+    let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+
+    init_core_1(
+        &mut pac.PSM,
+        &mut pac.PPB,
+        &mut sio.fifo,
+        clocks.system_clock.freq().to_Hz()
+    );
+
+    critical_section::with(|cs| {
+        SIO_FIFO.borrow(cs).replace(Some(sio.fifo));
+        LED_PIN.borrow(cs).replace(Some(pins.gpio13.reconfigure()));
+    });
 
     let spi_mosi = pins.gpio15.into_function::<hal::gpio::FunctionSpi>();
     let spi_miso = pins.gpio8.into_function::<hal::gpio::FunctionSpi>();
@@ -66,32 +205,52 @@ fn main() -> ! {
     );
     let spi_bus = RefCell::new(spi);
 
-    let mut led: Pin<_, FunctionSioOutput, PullDown> = pins.gpio13.reconfigure();
-
     let nss = pins.gpio16.into_push_pull_output_in_state(PinState::High);
     let reset = pins.gpio17.into_push_pull_output_in_state(PinState::High);
 
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
 
-    let message = "hello, world!";
-    let mut buffer = [0;255];
+    let message = "hello, world!\r\n";
+    let mut buffer = [0u8; 255];
     for (i,c) in message.chars().enumerate() {
         buffer[i] = c as u8;
     }
 
     loop {
-        match lora.transmit_payload(&buffer) {
-            Ok(_) => {
-                for _ in 0..3 {
-                    led.set_high().unwrap();
-                    timer.delay_ms(500);
-                    led.set_low().unwrap();
-                    timer.delay_ms(500);
-                }
+        let msg = match lora.transmit_payload(&buffer) {
+            Ok(_) => TxOk,
+            Err(e) => match e {
+                Sx127xError::Uninformative => ErrUninformative,
+                Sx127xError::VersionMismatch(_) => ErrVersionMismatch,
+                Sx127xError::Reset(_) => ErrReset,
+                Sx127xError::SPI(_) => ErrSpi,
+                Sx127xError::Transmitting => ErrTransmitting,
+                Sx127xError::Receiving => ErrReceiving,
             },
-            Err(_) => {}
-        }
-        timer.delay_ms(5000);
+        };
+        send_sio_fifo_msg(msg);
+        timer.delay_ms(5_000);
     }
+}
+
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    critical_section::with(|cs| {
+        let mut maybe_led = LED_PIN.borrow(cs).borrow_mut();
+        if let Some(led) = maybe_led.deref_mut() {
+            led.set_high().unwrap();
+        }
+    });
+    loop {}
+}
+
+fn send_sio_fifo_msg(msg: SioFifoMsg) {
+    critical_section::with(|cs| {
+        let mut maybe_sio_fifo = SIO_FIFO.borrow_ref_mut(cs);
+        if let Some(sio_fifo) = maybe_sio_fifo.as_mut() {
+            sio_fifo.write(msg as u32);
+        }
+    });
 }

--- a/examples/rp2040/examples/tx_interrupt.rs
+++ b/examples/rp2040/examples/tx_interrupt.rs
@@ -1,7 +1,10 @@
-//! Transmit packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
+//! Transmit packets and handle completion via interrupt using the LoRa 1276 module on the Adafruit
+//! Feather RP2040 RFM95 board.
 //!
-//! This will trigger the TxDone interrupt on DIO0 if transmission was successful and blink the
-//! on-board LED. On failure, the on-board LED will be turned on.
+//! The chip will trigger the TxDone interrupt on DIO0 if transmit was successful. Output is
+//! available via serial over a USB-C connection, and panics will turn the on-board LED on.
+//!
+//! Note that the `TxDone` interrupt needs to explicitly cleared by app code.
 
 #![no_std]
 #![no_main]
@@ -9,22 +12,71 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::ops::DerefMut;
+use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicBool, Ordering};
 use cortex_m::asm::wfi;
 use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
-use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
 use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown, PullNone};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
-use rp2040_hal::gpio::bank0::Gpio21;
+use rp2040_hal::gpio::bank0::{Gpio13, Gpio21};
 use rp2040_hal::gpio::Interrupt::EdgeHigh;
-use rp2040_hal::pac::interrupt;
-use sx127x_lora::Interrupt;
+use rp2040_hal::multicore::{Multicore, Stack};
+use rp2040_hal::pac::{interrupt, PPB, PSM};
+use rp2040_hal::sio::SioFifo;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::device::{StringDescriptors, UsbDeviceBuilder, UsbVidPid};
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+use sx127x_lora::{Interrupt, Sx127xError};
+use crate::SioFifoMsg::*;
+
+enum SioFifoMsg {
+    ErrReceiving = 0x0,
+    ErrReset = 0x1,
+    ErrSpi = 0x2,
+    ErrTransmitting = 0x3,
+    ErrUninformative = 0x4,
+    ErrVersionMismatch = 0x5,
+    PacketNotReady = 0x6,
+    TxOk = 0x7,
+}
+impl TryFrom<u32> for SioFifoMsg {
+    type Error = ();
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0 => Ok(ErrReceiving),
+            0x1 => Ok(ErrReset),
+            0x2 => Ok(ErrSpi),
+            0x3 => Ok(ErrTransmitting),
+            0x4 => Ok(ErrUninformative),
+            0x5 => Ok(ErrVersionMismatch),
+            0x6 => Ok(PacketNotReady),
+            0x7 => Ok(TxOk),
+            _ => Err(())
+        }
+    }
+}
+
+impl From<SioFifoMsg> for &[u8] {
+    fn from(value: SioFifoMsg) -> Self {
+        match value {
+            ErrReceiving => "LoRa TX err: receiving\r\n",
+            ErrReset => "LoRa TX err: reset\r\n",
+            ErrSpi => "LoRa TX err: SPI\r\n",
+            ErrTransmitting => "LoRa TX err: transmitting\r\n",
+            ErrUninformative => "LoRa TX err: uninformative\r\n",
+            ErrVersionMismatch => "LoRa TX err: version mismatch\r\n",
+            PacketNotReady => "LoRa TX: packet not ready\r\n",
+            TxOk => "LoRa TX ok\r\n",
+        }.as_bytes()
+    }
+}
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -33,6 +85,17 @@ use sx127x_lora::Interrupt;
 #[used]
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
+/// Stack for core 1
+///
+/// Core 0 gets its stack via the normal route - any memory not used by static values is
+/// reserved for stack and initialised by cortex-m-rt.
+/// To get the same for Core 1, we would need to compile everything separately and
+/// modify the linker file for both programs, and that's quite annoying.
+/// So instead, core1.spawn takes a [usize] which gets used for the stack.
+/// NOTE: We use the `Stack` struct here to ensure that it has 32-byte alignment, which allows
+/// the stack guard to take up the least amount of usable RAM.
+static CORE1_STACK: Stack<4096> = Stack::new();
+
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
 
@@ -40,10 +103,12 @@ type Dio0 = Pin<Gpio21, FunctionSioInput, PullDown>;
 
 static DIO0: Mutex<RefCell<Option<Dio0>>> = Mutex::new(RefCell::new(None));
 static DIO0_FLAG: AtomicBool = AtomicBool::new(false);
+static LED_PIN: Mutex<RefCell<Option<Pin<Gpio13, FunctionSioOutput, PullNone>>>> = Mutex::new(RefCell::new(None));
+static SIO_FIFO: Mutex<RefCell<Option<SioFifo>>> = Mutex::new(RefCell::new(None));
 
-#[rp2040_hal::entry]
-fn main() -> ! {
-    let mut pac = pac::Peripherals::take().unwrap();
+fn core1_task(_sys_freq: u32) -> ! {
+    let mut pac = unsafe { pac::Peripherals::steal() };
+    let mut sio = Sio::new(pac.SIO);
     let mut watchdog = Watchdog::new(pac.WATCHDOG);
 
     let clocks = init_clocks_and_plls(
@@ -57,13 +122,79 @@ fn main() -> ! {
     )
         .ok()
         .unwrap();
+
+    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
+        pac.USBCTRL_REGS,
+        pac.USBCTRL_DPRAM,
+        clocks.usb_clock,
+        true,
+        &mut pac.RESETS,
+    ));
+    let mut serial = SerialPort::new(&usb_bus);
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Raspberry Pi")
+            .product("RP2 USB Serial")
+            .serial_number("E0C9125B0D9B")])
+        .unwrap()
+        .device_class(USB_CLASS_CDC) // from: https://www.usb.org/defined-class-codes
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+        match sio.fifo.read() {
+            Some(word) => {
+                if let Ok(msg) = SioFifoMsg::try_from(word) {
+                    serial.write(msg.into()).unwrap();
+                } else {
+                    serial.write("Unexpected msg\r\n".as_bytes()).unwrap();
+                }
+            },
+            None => continue,
+        }
+    }
+}
+
+fn init_core_1(psm: &mut PSM, ppb: &mut PPB, fifo: &mut SioFifo, clk_freq: u32) {
+    let mut mc = Multicore::new(psm, ppb, fifo);
+    let cores = mc.cores();
+    let core1 = &mut cores[1];
+    let sys_freq = clk_freq;
+    let _ = core1.spawn(CORE1_STACK.take().unwrap(), move || core1_task(sys_freq));
+}
+
+#[rp2040_hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let mut sio = Sio::new(pac.SIO);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+        .ok()
+        .unwrap();
     let mut timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
-    let sio = Sio::new(pac.SIO);
     let pins = Pins::new(
         pac.IO_BANK0,
         pac.PADS_BANK0,
         sio.gpio_bank0,
         &mut pac.RESETS,
+    );
+
+    init_core_1(
+        &mut pac.PSM,
+        &mut pac.PPB,
+        &mut sio.fifo,
+        clocks.system_clock.freq().to_Hz()
     );
 
     let spi_mosi = pins.gpio15.into_function::<hal::gpio::FunctionSpi>();
@@ -77,8 +208,6 @@ fn main() -> ! {
         embedded_hal::spi::MODE_0,
     );
     let spi_bus = RefCell::new(spi);
-
-    let mut led: Pin<_, FunctionSioOutput, PullDown> = pins.gpio13.reconfigure();
 
     let nss = pins.gpio16.into_push_pull_output_in_state(PinState::High);
     let reset = pins.gpio17.into_push_pull_output_in_state(PinState::High);
@@ -98,6 +227,8 @@ fn main() -> ! {
 
     critical_section::with(|cs| {
         DIO0.borrow(cs).replace(Some(dio0));
+        SIO_FIFO.borrow(cs).replace(Some(sio.fifo));
+        LED_PIN.borrow(cs).replace(Some(pins.gpio13.reconfigure()));
     });
 
     unsafe {
@@ -105,24 +236,25 @@ fn main() -> ! {
     }
 
     loop {
-        wfi();
         if DIO0_FLAG.load(Ordering::Relaxed) {
             DIO0_FLAG.store(false, Ordering::Relaxed);
             lora.clear_interrupt(Interrupt::TxDone).unwrap();
+            timer.delay_ms(5_000);
         }
 
-        match lora.transmit_payload(&buffer) {
-            Ok(_) => {
-                {
-                    led.set_high().unwrap();
-                    timer.delay_ms(500);
-                    led.set_low().unwrap();
-                    timer.delay_ms(500);
-                }
-            }
-            Err(_) => led.set_high().unwrap()
-        }
-        timer.delay_ms(3000);
+        let msg = match lora.transmit_payload(&buffer) {
+            Ok(_) => TxOk,
+            Err(e) => match e {
+                Sx127xError::Uninformative => ErrUninformative,
+                Sx127xError::VersionMismatch(_) => ErrVersionMismatch,
+                Sx127xError::Reset(_) => ErrReset,
+                Sx127xError::SPI(_) => ErrSpi,
+                Sx127xError::Transmitting => ErrTransmitting,
+                Sx127xError::Receiving => ErrReceiving,
+            },
+        };
+        send_sio_fifo_msg(msg);
+        wfi();
     }
 }
 
@@ -135,4 +267,24 @@ fn IO_IRQ_BANK0() {
             dio0.clear_interrupt(EdgeHigh);
         }
     })
+}
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    critical_section::with(|cs| {
+        let mut maybe_led = LED_PIN.borrow(cs).borrow_mut();
+        if let Some(led) = maybe_led.deref_mut() {
+            led.set_high().unwrap();
+        }
+    });
+    loop {}
+}
+
+fn send_sio_fifo_msg(msg: SioFifoMsg) {
+    critical_section::with(|cs| {
+        let mut maybe_sio_fifo = SIO_FIFO.borrow_ref_mut(cs);
+        if let Some(sio_fifo) = maybe_sio_fifo.as_mut() {
+            sio_fifo.write(msg as u32);
+        }
+    });
 }

--- a/examples/rp2040/examples/tx_interrupt.rs
+++ b/examples/rp2040/examples/tx_interrupt.rs
@@ -1,7 +1,7 @@
 //! Transmit packets using the LoRa 1276 module on the Adafruit Feather RP2040 RFM95 board
 //!
-//! This will blink the on-board LED if transmission is successful. On failure, the on-board LED
-//! will be turned on.
+//! This will trigger the TxDone interrupt on DIO0 if transmission was successful and blink the
+//! on-board LED. On failure, the on-board LED will be turned on.
 
 #![no_std]
 #![no_main]
@@ -9,6 +9,9 @@
 extern crate sx127x_lora;
 
 use core::cell::RefCell;
+use core::sync::atomic::{AtomicBool, Ordering};
+use cortex_m::asm::wfi;
+use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{OutputPin, PinState};
 use embedded_hal_bus::spi::RefCellDevice;
@@ -16,8 +19,12 @@ use panic_halt as _;
 use rp2040_hal as hal;
 use rp2040_hal::clocks::init_clocks_and_plls;
 use rp2040_hal::fugit::RateExtU32;
-use rp2040_hal::gpio::{FunctionSioOutput, Pin, Pins, PullDown};
+use rp2040_hal::gpio::{FunctionSioInput, FunctionSioOutput, Pin, Pins, PullDown};
 use rp2040_hal::{Sio, Timer, Watchdog, pac, Clock};
+use rp2040_hal::gpio::bank0::Gpio21;
+use rp2040_hal::gpio::Interrupt::EdgeHigh;
+use rp2040_hal::pac::interrupt;
+use sx127x_lora::Interrupt;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -28,6 +35,11 @@ pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
 const XOSC_CRYSTAL_FREQ_HZ: u32 = 12_000_000;
 const LORA_FREQUENCY_MHZ: i64 = 915;
+
+type Dio0 = Pin<Gpio21, FunctionSioInput, PullDown>;
+
+static DIO0: Mutex<RefCell<Option<Dio0>>> = Mutex::new(RefCell::new(None));
+static DIO0_FLAG: AtomicBool = AtomicBool::new(false);
 
 #[rp2040_hal::entry]
 fn main() -> ! {
@@ -73,6 +85,10 @@ fn main() -> ! {
 
     let spi_device = RefCellDevice::new(&spi_bus, nss, timer).unwrap();
     let mut lora = sx127x_lora::LoRa::new(spi_device, reset, LORA_FREQUENCY_MHZ).unwrap();
+    lora.enable_interrupt(Interrupt::TxDone).unwrap();
+
+    let dio0: Pin<Gpio21, FunctionSioInput, PullDown> = pins.gpio21.reconfigure();
+    dio0.set_interrupt_enabled(EdgeHigh, true);
 
     let message = "hello, world!";
     let mut buffer = [0;255];
@@ -80,18 +96,43 @@ fn main() -> ! {
         buffer[i] = c as u8;
     }
 
+    critical_section::with(|cs| {
+        DIO0.borrow(cs).replace(Some(dio0));
+    });
+
+    unsafe {
+        pac::NVIC::unmask(pac::Interrupt::IO_IRQ_BANK0);
+    }
+
     loop {
+        wfi();
+        if DIO0_FLAG.load(Ordering::Relaxed) {
+            DIO0_FLAG.store(false, Ordering::Relaxed);
+            lora.clear_interrupt(Interrupt::TxDone).unwrap();
+        }
+
         match lora.transmit_payload(&buffer) {
             Ok(_) => {
-                for _ in 0..3 {
+                {
                     led.set_high().unwrap();
                     timer.delay_ms(500);
                     led.set_low().unwrap();
                     timer.delay_ms(500);
                 }
-            },
-            Err(_) => {}
+            }
+            Err(_) => led.set_high().unwrap()
         }
-        timer.delay_ms(5000);
+        timer.delay_ms(3000);
     }
+}
+
+#[interrupt]
+fn IO_IRQ_BANK0() {
+    critical_section::with(|cs| {
+        let mut maybe_dio0 = DIO0.borrow(cs).borrow_mut();
+        if let Some(dio0) = maybe_dio0.as_mut() {
+            DIO0_FLAG.store(true, Ordering::Relaxed);
+            dio0.clear_interrupt(EdgeHigh);
+        }
+    })
 }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,24 @@
+use crate::register::Register;
+
+#[derive(Clone, Copy)]
+pub enum Interrupt {
+    RxDone = 0x0,
+    TxDone = 0x40,
+}
+
+impl Interrupt {
+    pub fn flag(self) -> u8 {
+        match self {
+            Interrupt::RxDone => 0x40,
+            Interrupt::TxDone => 0x08
+        }
+    }
+
+    pub fn mask(self) -> u8 {
+        0xc0 // only supporting DIO0 for now
+    }
+
+    pub fn reg_addr(self) -> u8 {
+        Register::RegDioMapping1.addr() // only supporting DIO0 for now
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,136 +9,7 @@
 //! RESET. This cate works with any Semtech based board including:
 //! * Modtronix inAir4, inAir9, and inAir9B
 //! * HopeRF RFM95W, RFM96W, and RFM98W
-//! # Examples
-//! ## Raspberry Pi Basic Send
-//! Utilizes a Raspberry Pi to send a message. The example utilizes the `linux_embedded_hal` crate.
-//! ```no_run
-//! #![feature(extern_crate_item_prelude)]
-//! extern crate sx127x_lora;
-//! extern crate linux_embedded_hal as hal;
-//!
-//! use hal::spidev::{self, SpidevOptions};
-//! use hal::{Pin, Spidev};
-//! use hal::sysfs_gpio::Direction;
-//! use hal::Delay;
-
-//! const LORA_CS_PIN: u64 = 8;
-//! const LORA_RESET_PIN: u64 = 21;
-//! const FREQUENCY: i64 = 915;
-//!
-//! fn main(){
-//!
-//!     let mut spi = Spidev::open("/dev/spidev0.0").unwrap();
-//!     let options = SpidevOptions::new()
-//!         .bits_per_word(8)
-//!         .max_speed_hz(20_000)
-//!         .mode(spidev::SPI_MODE_0)
-//!         .build();
-//!     spi.configure(&options).unwrap();
-//!
-//!     let cs = Pin::new(LORA_CS_PIN);
-//!     cs.export().unwrap();
-//!     cs.set_direction(Direction::Out).unwrap();
-//!
-//!     let reset = Pin::new(LORA_RESET_PIN);
-//!     reset.export().unwrap();
-//!     reset.set_direction(Direction::Out).unwrap();
-//!
-//!     let mut lora = sx127x_lora::LoRa::new(
-//!         spi, cs, reset,  FREQUENCY, Delay)
-//!         .expect("Failed to communicate with radio module!");
-//!
-//!     lora.set_tx_power(17,1); //Using PA_BOOST. See your board for correct pin.
-//!
-//!     let message = "Hello, world!";
-//!     let mut buffer = [0;255];
-//!     for (i,c) in message.chars().enumerate() {
-//!         buffer[i] = c as u8;
-//!     }
-//!
-//!     let transmit = lora.transmit_payload(buffer,message.len());
-//!     match transmit {
-//!         Ok(packet_size) => println!("Sent packet with size: {}", packet_size),
-//!         Err(()) => println!("Error"),
-//!     }
-//! }
-//! ```
-//! ## STM32F429 Blocking Receive
-//! Utilizes a STM32F429 to receive data using the blocking `poll_irq(timeout)` function. It prints
-//! the received packet back out over semihosting. The example utilizes the `stm32f429_hal`, `cortex_m`,
-//! and `panic_semihosting` crates.
-//! ```no_run
-//! #![no_std]
-//! #![no_main]
-//!
-//! extern crate sx127x_lora;
-//! extern crate stm32f429_hal as hal;
-//! extern crate cortex_m;
-//! extern crate panic_semihosting;
-//!
-//! use sx127x_lora::MODE;
-//! use cortex_m_semihosting::*;
-//! use hal::gpio::GpioExt;
-//! use hal::flash::FlashExt;
-//! use hal::rcc::RccExt;
-//! use hal::time::MegaHertz;
-//! use hal::spi::Spi;
-//! use hal::delay::Delay;
-//!
-//! const FREQUENCY: i64 = 915;
-//!
-//! #[entry]
-//! fn main() -> !{
-//!     let cp = cortex_m::Peripherals::take().unwrap();
-//!     let p = hal::stm32f429::Peripherals::take().unwrap();
-//!
-//!     let mut rcc = p.RCC.constrain();
-//!     let mut flash = p.FLASH.constrain();
-//!     let clocks = rcc
-//!         .cfgr
-//!         .sysclk(MegaHertz(64))
-//!         .pclk1(MegaHertz(32))
-//!         .freeze(&mut flash.acr);
-//!
-//!     let mut gpioa = p.GPIOA.split(&mut rcc.ahb1);
-//!     let mut gpiod = p.GPIOD.split(&mut rcc.ahb1);
-//!     let mut gpiof = p.GPIOF.split(&mut rcc.ahb1);
-//!
-//!     let sck = gpioa.pa5.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-//!     let miso = gpioa.pa6.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-//!     let mosi = gpioa.pa7.into_af5(&mut gpioa.moder, &mut gpioa.afrl);
-//!     let reset = gpiof.pf13.into_push_pull_output(&mut gpiof.moder, &mut gpiof.otyper);
-//!     let cs = gpiod.pd14.into_push_pull_output(&mut gpiod.moder, &mut gpiod.otyper);
-//!
-//!     let spi = Spi::spi1(
-//!         p.SPI1,
-//!         (sck, miso, mosi),
-//!         MODE,
-//!         MegaHertz(8),
-//!         clocks,
-//!         &mut rcc.apb2,
-//!     );
-//!
-//!     let mut lora = sx127x_lora::LoRa::new(
-//!         spi, cs, reset, FREQUENCY,
-//!         Delay::new(cp.SYST, clocks)).unwrap();
-//!
-//!     loop {
-//!         let poll = lora.poll_irq(Some(30)); //30 Second timeout
-//!         match poll {
-//!             Ok(size) =>{
-//!                hprint!("with Payload: ");
-//!                let buffer = lora.read_packet(); // Received buffer. NOTE: 255 bytes are always returned
-//!                for i in 0..size{
-//!                    hprint!("{}",buffer[i] as char).unwrap();
-//!                }
-//!                hprintln!();
-//!             },
-//!             Err(()) => hprintln!("Timeout").unwrap(),
-//!         }
-//!     }
-//! }
-//! ```
+//! * Adafruit RP2040 RFM95
 //! ## Interrupts
 //! The crate currently polls the IRQ register on the radio to determine if a new packet has arrived. This
 //! would be more efficient if instead an interrupt was connected the module's DIO_0 pin. Once interrupt
@@ -150,9 +21,11 @@ use embedded_hal::digital::{ErrorType, OutputPin};
 use embedded_hal::spi::{Mode, Operation, Phase, Polarity, SpiDevice};
 
 mod register;
+mod interrupt;
+
 use self::register::PaConfig;
 use self::register::Register;
-use self::register::IRQ;
+pub use self::interrupt::Interrupt;
 
 /// Provides the necessary SPI mode configuration for the radio
 pub const MODE: Mode = Mode {
@@ -176,6 +49,7 @@ pub enum Sx127xError<SPI, RESET> {
     Reset(RESET),
     SPI(SPI),
     Transmitting,
+    Receiving,
 }
 
 use crate::register::{FskDataModulationShaping, FskRampUpRamDown};
@@ -270,6 +144,7 @@ where
         }
     }
 
+    /// Reset the chip.
     pub fn reset(&mut self) -> Result<(), Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
         self.reset.set_low().map_err(Reset)?;
         self.spi.transaction(&mut [Operation::DelayNs(10_000_000)]).map_err(SPI)?;
@@ -278,8 +153,19 @@ where
         Ok(())
     }
 
-    pub fn set_dio0_tx_done(&mut self) -> Result<(), Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
-        self.write_register(Register::RegDioMapping1.addr(), 0b01_00_00_00)
+    /// Enables an interrupt.
+    pub fn enable_interrupt(&mut self, interrupt: Interrupt) -> Result<(), Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
+        let mut reg_val = self.read_register(interrupt.reg_addr())?;
+        reg_val = reg_val & !interrupt.mask() | (interrupt as u8) & interrupt.mask();
+        self.write_register(interrupt.reg_addr(), reg_val)?;
+        Ok(())
+    }
+
+    /// Clears an interrupt.
+    pub fn clear_interrupt(&mut self, interrupt: Interrupt) -> Result<(), Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
+        let reg_val = self.read_register(Register::RegIrqFlags.addr())?;
+        self.write_register(Register::RegIrqFlags.addr(), reg_val | interrupt.flag())?;
+        Ok(())
     }
 
     pub fn transmit_payload(
@@ -328,7 +214,6 @@ where
                         break packet_ready;
                     }
                     count += 1;
-                    // delay.delay_ms(1);
                     self.spi.transaction(&mut [Operation::DelayNs(1_000_000)]).map_err(SPI)?;
 
                 };
@@ -341,7 +226,6 @@ where
             }
             None => {
                 while !self.read_register(Register::RegIrqFlags.addr())?.get_bit(6) {
-                    // delay.delay_ms(100);
                     self.spi.transaction(&mut [Operation::DelayNs(100_000_000)]).map_err(SPI)?;
 
                 }
@@ -354,8 +238,19 @@ where
     /// Returns the contents of the fifo as a fixed 255 u8 array. This should only be called if there is a
     /// new packet ready to be read.
     pub fn read_packet(&mut self) -> Result<[u8; 255], Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
+        // check CrcOnPayload bit to determine if CRC validation is needed
+        let reg_hop_channel = self.read_register(Register::RegHopChannel.addr())?;
+        if (reg_hop_channel >> 6 & 0x1) == 1 {
+            // if ValidHeader, PayloadCrcError, RxDone or RxTimeout bits are set, then packet
+            // termination was unsuccessful
+            let reg_irq_flags = self.read_register(Register::RegIrqFlags.addr())?;
+            if (reg_irq_flags >> 4) & 0xf != 0x0 {
+                return Err(Receiving)
+            }
+        }
+
         let mut buffer = [0u8; 255];
-        self.clear_irq()?;
+        //self.clear_irq()?;
         let size = self.get_ready_packet_size()?;
         let fifo_addr = self.read_register(Register::RegFifoRxCurrentAddr.addr())?;
         self.write_register(Register::RegFifoAddrPtr.addr(), fifo_addr)?;
@@ -381,15 +276,16 @@ where
         {
             Ok(true)
         } else {
-            if (self.read_register(Register::RegIrqFlags.addr())? & IRQ::IrqTxDoneMask.addr()) == 1
+            if (self.read_register(Register::RegIrqFlags.addr())? & Interrupt::TxDone.flag()) == 1
             {
-                self.write_register(Register::RegIrqFlags.addr(), IRQ::IrqTxDoneMask.addr())?;
+                self.write_register(Register::RegIrqFlags.addr(), Interrupt::TxDone.flag())?;
             }
             Ok(false)
         }
     }
 
     /// Clears the radio's IRQ registers.
+    // TODO figure out what this does (if anything)
     pub fn clear_irq(&mut self) -> Result<(), Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
         let irq_flags = self.read_register(Register::RegIrqFlags.addr())?;
         self.write_register(Register::RegIrqFlags.addr(), irq_flags)
@@ -684,14 +580,14 @@ where
         self.write_register(Register::RegModemConfig3.addr(), config_3)
     }
 
-    pub fn read_register(&mut self, reg: u8) -> Result<u8, Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
+    fn read_register(&mut self, reg: u8) -> Result<u8, Sx127xError<SPI::Error, <RESET as ErrorType>::Error>> {
         let mut read = [0; 2];
         let write = [reg & 0x7f, 0];
         self.spi.transfer(&mut read, &write).map_err(SPI)?;
         Ok(read[1])
     }
 
-    pub fn write_register(
+    fn write_register(
         &mut self,
         reg: u8,
         byte: u8,

--- a/src/register.rs
+++ b/src/register.rs
@@ -87,3 +87,36 @@ pub enum FskRampUpRamDown {
     _12us = 0b1110,
     _10us = 0b1111
 }
+
+pub(crate) fn crc_validation_needed(reg_hop_channel: u8) -> bool {
+    (reg_hop_channel >> 6 & 0x1) == 1
+}
+
+pub(crate) fn rx_packet_termination_ok(reg_irq_flags: u8) -> bool {
+    (reg_irq_flags >> 4) & 0xf == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crc_validation_needed_false() {
+        assert!(!crc_validation_needed(0b1011_1111));
+    }
+
+    #[test]
+    fn crc_validation_needed_true() {
+        assert!(crc_validation_needed(0b1111_1111));
+    }
+
+    #[test]
+    fn rx_packet_termination_ok_false() {
+        assert!(!rx_packet_termination_ok(0b1000_1111));
+    }
+
+    #[test]
+    fn rx_packet_termination_ok_true() {
+        assert!(rx_packet_termination_ok(0b0000_1111));
+    }
+}

--- a/src/register.rs
+++ b/src/register.rs
@@ -19,6 +19,7 @@ pub enum Register {
     RegRxNbBytes = 0x13,
     RegPktSnrValue = 0x19,
     RegPktRssiValue = 0x1a,
+    RegHopChannel = 0x1c,
     RegModemConfig1 = 0x1d,
     RegModemConfig2 = 0x1e,
     RegPreambleMsb = 0x20,
@@ -46,13 +47,6 @@ pub enum PaConfig {
     PaOutputRfoPin = 0,
 }
 
-#[derive(Clone, Copy)]
-pub enum IRQ {
-    IrqTxDoneMask = 0x08,
-    IrqPayloadCrcErrorMask = 0x20,
-    IrqRxDoneMask = 0x40,
-}
-
 impl Register {
     pub fn addr(self) -> u8 {
         self as u8
@@ -60,12 +54,6 @@ impl Register {
 }
 
 impl PaConfig {
-    pub fn addr(self) -> u8 {
-        self as u8
-    }
-}
-
-impl IRQ {
     pub fn addr(self) -> u8 {
         self as u8
     }


### PR DESCRIPTION
Formal integration of interrupts (beyond `set_interrupt_enabled(...)`) into `embedded-hal` is still an [open discussion](https://github.com/rust-embedded/embedded-hal/issues/57), so I added a few methods, abstractions and examples to demonstrate what's possible with `embedded-hal=1.0`.

**CHANGES:**
- added clear/enable_interrupt methods to public API
- added interrupt module and enum to standardize and clarify usage
- removed `set_dio0_tx_done(...)`
- removed `pub` from read/write_register that were erroneously included in previous PR+merge
- excluded `examples/*` when publishing
- added function to validate the rx packet before reading the packet (see p41 of https://semtech.my.salesforce.com/sfc/p/E0000000JelG/a/2R0000001Rbr/6EfVZUorrpoKFfvaF_Fkpgp5kzjiNyiAbqcpqh9qSjE)
- broke out rx packet validation register logic for easy unit testing (vs mocking SPI bus)
- added tx_interrupt and rx_interrupt examples
- updated all rp2040 examples to write out to serial over USB-C
- updated README interrupt section and todos